### PR TITLE
Install sphinx-cjkspace to remove extra whitespaces between CJK chars

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx_rtd_theme
+sphinx-cjkspace>=0.1.3

--- a/source/conf.py
+++ b/source/conf.py
@@ -29,6 +29,7 @@ copyright = f"2020, {author}."
 # ones.
 extensions = [
     "sphinx.ext.githubpages",
+    "sphinx_cjkspace.cjkspace",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
See [seismo-learn/software#38](https://github.com/seismo-learn/software/pull/38) for context.﻿
